### PR TITLE
feat: add unmount functionality to mounted components

### DIFF
--- a/packages/xtensio/src/loaders/importReactLoader.ts
+++ b/packages/xtensio/src/loaders/importReactLoader.ts
@@ -34,22 +34,6 @@ const getLinkTag = () => {
   return __linkTag;
 }
 
-const __mObserver = new MutationObserver((mutationsList, observer)=> {
-  for (const mutation of mutationsList) {
-    if (mutation.type === 'childList') {
-      if(mutation.target?.parentElement?.tagName === "HTML" && !document.querySelector("${appName}")) __mount();
-      mutation.addedNodes.forEach((node) => {
-        if (/(${appName}-mount)/i.test(node.nodeName)) {
-          const shadowEl = node.querySelector("[shadow-root='${appName}-mount']");
-          if(!shadowEl) return;
-          shadowEl.shadowRoot.prepend(getLinkTag());
-        }
-      });
-    }
-  }
-});
-__mObserver.observe(document.querySelector("html") || document.body, {childList: true, subtree: true });
-
 function __mount(){
   console.log("xtensio: mounting...");
   let el;

--- a/packages/xtensio/src/loaders/importReactLoader.ts
+++ b/packages/xtensio/src/loaders/importReactLoader.ts
@@ -34,6 +34,14 @@ const getLinkTag = () => {
   return __linkTag;
 }
 
+const __mObserver = new MutationObserver((mutationsList, observer)=> {
+  for (const mutation of mutationsList) {
+    if (mutation.type === 'childList' && Array.from(mutation.removedNodes).some(node=> node.tagName === "HTML") && !document.querySelector("${appName}"))
+      __mount()
+  }
+});
+__mObserver.observe(document.documentElement.parentNode, {childList: true });
+
 function __mount(){
   console.log("xtensio: mounting...");
   let el;

--- a/packages/xtensio/types/lib.ts
+++ b/packages/xtensio/types/lib.ts
@@ -4,3 +4,6 @@ export interface ContentConfig {
   shadowRoot?: boolean
   component?: React.ComponentType | string
 }
+
+export type MountComponent<T = {}> = React.FC<T & { unmount?: () => void }>
+export type MC<T = {}> = MountComponent<T>


### PR DESCRIPTION
#### Description
Adds unmount functionality to components that have been mounted using the internal function. Provides 2 ways of unmounting. 
1. At the mount point
2. Inside the React component that was mounted

It also provides typing `MountComponent` or `MC` when using with typescript react.

#### 1. At the mount point
```js
import { mount } from "xtensio"
...
const unmount = await mount(<PopupComponent />, document.body);
// call the returned function to unmount the component when you need to
unmount();
...
```

#### 2. Inside the React component that was mounted
```js
import { mount, MountComponent } from "xtensio"
...
const PopupComponent: MountComponent = ({ unmount! }) => {
	React.useEffect(()=> {
		setTimeout(()=> {
			// unmount 5 seconds after the element was mounted
			unmount();
		}, 5000)
	}, [])
	return <div>This is the popup component</div>
}
...
mount(<PopupComponent />, document.body);
...
```

#### Typing
When using react, you can use either `MountComponent` or `MC` to type the component to be mounted. this gives you access to the `unmount` function. You can also decided to use your own component typing but the `unmount` prop will always be overridden. 

#### Resolved
#9 
