### PR TITLE
feat: use tailwind without importing tailwind.css

### DIFF
--- a/packages/xtensio/src/config/projectPaths.ts
+++ b/packages/xtensio/src/config/projectPaths.ts
@@ -15,6 +15,7 @@ export interface ProjectPaths {
   npmLock: string
   publicPath: string
   tailwindPath: string
+  tailwindCssPath: string
 }
 
 function getJsFilePath(absPath: string, required = true) {
@@ -49,6 +50,7 @@ export default function getProjectPaths(cwd: string): ProjectPaths {
     pagesFolder: path.join(_cwd, "./pages"),
     npmLock: path.join(cwd, "./package-lock.json"),
     publicPath: path.join(cwd, "./public"),
-    tailwindPath: path.join(cwd, "./tailwind.config.js")
+    tailwindPath: path.join(cwd, "./tailwind.config.js"),
+    tailwindCssPath: path.join(_cwd, "./tailwind.css")
   }
 }

--- a/packages/xtensio/src/config/webpack.config.ts
+++ b/packages/xtensio/src/config/webpack.config.ts
@@ -17,6 +17,7 @@ import ManifestGenPlugin from "../plugins/ManifestGenPlugin"
 import { ProjectPaths } from "./projectPaths"
 import sandboxExec from "../sandbox/helper"
 import ExtensionContentsHMRPlugin from "../loaders/contents-hmr/ExtensionContentsHMRPlugin"
+import IgnoreEntriesPlugin from "../plugins/IgnoreEntriesPlugin"
 
 // TODO add a loader for the background page.
 // on install or refresh, check all open tabs using contentConfig and inject corresponding content
@@ -270,7 +271,8 @@ export const getXtensioWebpackConfig = async (
         : {}),
       ...contentsEntry,
       ...pagesEntry,
-      manifest: mPaths.manifest
+      manifest: mPaths.manifest,
+      globalcss: useTailwind ? mPaths.tailwindCssPath : []
     },
     output: {
       path: isDev ? mPaths.devOutput : mPaths.prodOutput,
@@ -381,6 +383,7 @@ export const getXtensioWebpackConfig = async (
           ...devManifest
         }
       }),
+      new IgnoreEntriesPlugin({ ignoreEntries: ["globalcss"] }),
       isDev && new ReactRefreshPlugin(),
       isDev && new webpack.HotModuleReplacementPlugin(),
       new webpack.DefinePlugin({

--- a/packages/xtensio/src/loaders/functions.ts
+++ b/packages/xtensio/src/loaders/functions.ts
@@ -1,0 +1,7 @@
+export function __getLinkTag(appName: string) {
+  const styleLink = chrome.runtime.getURL(`${appName}-styles.css`)
+  const linkTag = document.createElement("link")
+  linkTag.rel = "stylesheet"
+  linkTag.href = styleLink
+  return linkTag
+}

--- a/packages/xtensio/src/loaders/importReactLoader.ts
+++ b/packages/xtensio/src/loaders/importReactLoader.ts
@@ -1,6 +1,7 @@
 import path from "path"
 import { LoaderContext } from "webpack"
 import { ContentConfig } from "../../types/lib"
+import { __getLinkTag } from "./functions"
 
 interface Options {
   configMap: Map<string, ContentConfig>
@@ -25,15 +26,7 @@ export default function importReactLoader(
       return `
 import { createRoot as __createRoot } from "react-dom/client";
 ${source}
-// Extension styles here!
-const getLinkTag = () => {
-  const __styleLink = chrome.runtime.getURL("${appName}-styles.css");
-  const __linkTag = document.createElement("link");
-  __linkTag.rel = "stylesheet";
-  __linkTag.href = __styleLink;
-  return __linkTag;
-}
-
+${__getLinkTag.toString()}
 const __mObserver = new MutationObserver((mutationsList, observer)=> {
   for (const mutation of mutationsList) {
     if (mutation.type === 'childList' && Array.from(mutation.removedNodes).some(node=> node.tagName === "HTML") && !document.querySelector("${appName}"))
@@ -52,7 +45,7 @@ function __mount(){
   __appShadowRoot.setAttribute("shadow-root", "${appName}");
   __appHost.append(__appShadowRoot);
   document.querySelector("html").append(__appHost);
-  __appShadowRoot.attachShadow({ mode: "open" }).append(getLinkTag(), __appRoot);
+  __appShadowRoot.attachShadow({ mode: "open" }).append(__getLinkTag("${appName}"), __appRoot);
   const __root = __createRoot(__appRoot);
   __root.render(<${contentConfig.component}/>);
 }

--- a/packages/xtensio/src/loaders/reactMountLoader.ts
+++ b/packages/xtensio/src/loaders/reactMountLoader.ts
@@ -1,5 +1,6 @@
 import { LoaderContext } from "webpack"
 import { findDefaultExportName } from "../helper"
+import { __getLinkTag } from "./functions"
 
 interface Options {
   appName: string
@@ -15,6 +16,7 @@ export default function injectReactLoader(
   return `
 import { createRoot as __createRoot } from "react-dom/client";
 ${source}
+${__getLinkTag.toString()}
 function __mount(){
   console.log("xtensio: mounting...");
   let el;
@@ -23,6 +25,7 @@ function __mount(){
   const __appRoot = document.createElement("div");
   __appHost.append(__appRoot);
   document.body.append(__appHost);
+  document.head.append(__getLinkTag("${appName}"));
   const __root = __createRoot(__appRoot);
   __root.render(<${defaultName}/>)
 }

--- a/packages/xtensio/src/plugins/IgnoreEntriesPlugin.ts
+++ b/packages/xtensio/src/plugins/IgnoreEntriesPlugin.ts
@@ -1,0 +1,30 @@
+import { Compiler } from "webpack"
+
+interface IgnoreEntriesPluginOptions {
+  ignoreEntries: string[]
+}
+
+class IgnoreEntriesPlugin {
+  constructor(private options: IgnoreEntriesPluginOptions) {}
+
+  apply(compiler: Compiler) {
+    compiler.hooks.thisCompilation.tap(
+      IgnoreEntriesPlugin.name,
+      (compilation) => {
+        compilation.hooks.processAssets.tapPromise(
+          IgnoreEntriesPlugin.name,
+          async (assets) => {
+            Object.keys(assets).forEach((key) => {
+              const name = key.split(".")?.[0]
+              if (this.options.ignoreEntries.includes(name)) {
+                compilation.deleteAsset(key)
+              }
+            })
+          }
+        )
+      }
+    )
+  }
+}
+
+export default IgnoreEntriesPlugin

--- a/packages/xtensio/src/plugins/ManifestGenPlugin.ts
+++ b/packages/xtensio/src/plugins/ManifestGenPlugin.ts
@@ -43,12 +43,17 @@ class ManifestGenPlugin {
               ]
             }
             const outSource = JSON.stringify(manifestObj, null, 2)
-            compilation.deleteAsset(this.options.filename)
             compilation.emitAsset(
               this.options.outFilename,
               new sources.RawSource(outSource)
             )
           }
+          Object.keys(assets).forEach((key) => {
+            const name = key.split(".")?.[0]
+            if (name === "manifest" && key !== this.options.outFilename) {
+              compilation.deleteAsset(key)
+            }
+          })
         }
       )
     })


### PR DESCRIPTION
#### Description
This PR allows you to use tailwind everywhere as far as you've opted in without having to import `tailwind.css` wherever you want to use tailwind.

#### Resolves
#6 