### PR TITLE
feat: keep hot-update files in memory

### DIFF
--- a/packages/xtensio/src/dev.ts
+++ b/packages/xtensio/src/dev.ts
@@ -26,7 +26,12 @@ export default function devCommand(cwd: string) {
     })
     app.use(
       devMiddleware(compiler, {
-        writeToDisk: true
+        writeToDisk: (filePath) => {
+          return (
+            !/hot-update\.json$/.test(filePath) &&
+            !/hot-update\.js$/.test(filePath)
+          )
+        }
       })
     )
 


### PR DESCRIPTION
### Description
We're back to keeping hot-update files in memory. This is to prevent a bloated `.xtensio/dist` folder during long development.

<table><thead>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr></thead>
<tbody>
  <tr>
    <td>
<img width="466" alt="Screenshot 2024-11-02 at 1 19 30 PM" src="https://github.com/user-attachments/assets/d7a6058e-e2d4-4627-b488-ce9f7cee6341">
</td>
    <td>
<img width="403" alt="Screenshot 2024-11-02 at 1 18 23 PM" src="https://github.com/user-attachments/assets/25fdbd3b-9bbc-4cbb-9b0e-69d082ff3b6f">
</td>
  </tr>
</tbody>
</table>